### PR TITLE
Fix cart item details and location names

### DIFF
--- a/VERIFICACION.md
+++ b/VERIFICACION.md
@@ -166,7 +166,7 @@
 
 ## 🗺️ Integración Google Maps
 - ✅ Iframe de Google Maps en contacto
-- ✅ Ubicación: Latacunga, Ecuador
+- ✅ Ubicación: Anbato, Ecuador
 - ✅ Diseño responsivo del mapa
 
 ## ✅ Estado Final

--- a/VERIFICACION_FINAL.md
+++ b/VERIFICACION_FINAL.md
@@ -75,7 +75,7 @@
 
 ### 🗺️ **Google Maps**
 - ✅ Iframe integrado en contacto
-- ✅ Ubicación: Latacunga, Ecuador
+- ✅ Ubicación: Anbato, Ecuador
 
 ## 🧪 **Cómo Verificar el Sistema**
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -41,16 +41,19 @@ function updateCartCount() {
     }
 }
 
-function addToCart(productId, quantity = 1) {
+function addToCart(productId, name, price, image, quantity = 1) {
     // Find if product already exists in cart
     const existingItem = cart.find(item => item.id == productId);
-    
+
     if (existingItem) {
         existingItem.quantity += quantity;
     } else {
-        // Get product details (this would typically come from an API call)
+        // Store product details for later display
         cart.push({
             id: productId,
+            name: name,
+            price: price,
+            image: image,
             quantity: quantity,
             timestamp: new Date().toISOString()
         });
@@ -118,6 +121,9 @@ function initializeEventListeners() {
             e.preventDefault();
             const button = e.target.classList.contains('add-to-cart') ? e.target : e.target.closest('.add-to-cart');
             const productId = button.getAttribute('data-product-id') || button.getAttribute('onclick')?.match(/\d+/)?.[0];
+            const name = button.getAttribute('data-product-name');
+            const price = parseFloat(button.getAttribute('data-product-price')) || 0;
+            const image = button.getAttribute('data-product-image');
             const quantity = parseInt(button.getAttribute('data-quantity')) || 1;
             
             if (productId) {
@@ -130,7 +136,7 @@ function initializeEventListeners() {
                 
                 // Simulate API call delay
                 setTimeout(() => {
-                    addToCart(productId, quantity);
+                    addToCart(productId, name, price, image, quantity);
                     
                     // Reset button with success animation
                     button.innerHTML = '<i class="fas fa-check me-2"></i>¡Agregado!';

--- a/cart.php
+++ b/cart.php
@@ -239,7 +239,7 @@ $product = new Product();
                 <div class="col-lg-2 col-md-6 mb-4">
                     <h6 class="fw-bold mb-3">Contacto</h6>
                     <ul class="list-unstyled text-muted">
-                        <li><i class="fas fa-map-marker-alt me-2"></i>Latacunga, Ecuador</li>
+                        <li><i class="fas fa-map-marker-alt me-2"></i>Anbato, Ecuador</li>
                         <li><i class="fas fa-phone me-2"></i>+593 983015307</li>
                         <li><i class="fas fa-envelope me-2"></i>kevinmoyolema13@gmail.com</li>
                     </ul>
@@ -251,7 +251,7 @@ $product = new Product();
                     <p class="text-muted mb-0">&copy; 2025 AlquimiaTechnologic. Desarrollado por AlquimiaTechnologic. Todos los derechos reservados.</p>
                 </div>
                 <div class="col-md-6 text-md-end">
-                    <p class="text-muted mb-0">Hecho con <i class="fas fa-heart text-danger"></i> en Colombia</p>
+                    <p class="text-muted mb-0">Hecho con <i class="fas fa-heart text-danger"></i> en Ecuador</p>
                 </div>
             </div>
         </div>
@@ -286,17 +286,16 @@ $product = new Product();
                 return;
             }
             
-            // Simulate loading cart items (in real app, this would fetch from API)
+            // Cargar productos del carrito con la información almacenada
             let cartHTML = '';
             let total = 0;
-            
+
             cart.forEach((item, index) => {
-                // Simulate product data (in real app, this would come from database)
                 const product = {
                     id: item.id,
-                    name: `Producto ${item.id}`,
-                    price: 99000,
-                    image: 'assets/images/placeholder.jpg'
+                    name: item.name,
+                    price: item.price,
+                    image: item.image
                 };
                 
                 const itemTotal = product.price * item.quantity;
@@ -360,13 +359,13 @@ $product = new Product();
         
         function updateCartSummary() {
             const cart = JSON.parse(localStorage.getItem('cart')) || [];
-            const total = cart.reduce((sum, item) => sum + (99000 * item.quantity), 0);
+            const total = cart.reduce((sum, item) => sum + (item.price * item.quantity), 0);
             
             document.getElementById('subtotal').textContent = `$${total.toLocaleString()}`;
             document.getElementById('total').textContent = `$${total.toLocaleString()}`;
             
             // Update WhatsApp link with cart items
-            const cartItems = cart.map(item => `Producto ${item.id} x${item.quantity}`).join(', ');
+            const cartItems = cart.map(item => `${item.name} x${item.quantity}`).join(', ');
             const whatsappLink = `https://wa.me/593983015307?text=Hola%2C%20quiero%20completar%20mi%20compra%20del%20carrito%20de%20AlquimiaTechnologic%20-%20${encodeURIComponent(cartItems)}%20-%20Total:%20$${total.toLocaleString()}`;
             document.getElementById('whatsapp-checkout').href = whatsappLink;
         }

--- a/category.php
+++ b/category.php
@@ -200,8 +200,9 @@ $totalPages = ceil($totalProducts / $limit);
                                     <img src="<?php echo $prod['image'] ?: 'assets/images/placeholder.jpg'; ?>" 
                                          alt="<?php echo htmlspecialchars($prod['name']); ?>" 
                                          class="img-fluid">
+                                    <?php $finalPrice = (isset($prod['discount_percentage']) && $prod['discount_percentage'] > 0) ? $prod['price'] * (1 - $prod['discount_percentage']/100) : $prod['price']; ?>
                                     <div class="product-overlay">
-                                        <button class="btn btn-light btn-sm me-2 hover-glow" onclick="addToCart(<?php echo $prod['id']; ?>)" title="Agregar al carrito">
+                                        <button class="btn btn-light btn-sm me-2 hover-glow" onclick="addToCart(<?php echo $prod['id']; ?>, '<?php echo addslashes($prod['name']); ?>', <?php echo $finalPrice; ?>, '<?php echo $prod['image'] ?: 'assets/images/placeholder.jpg'; ?>')" title="Agregar al carrito">
                                             <i class="fas fa-shopping-cart"></i>
                                         </button>
                                         <button class="btn btn-light btn-sm me-2 hover-glow" onclick="quickView(<?php echo $prod['id']; ?>)" title="Vista rápida">
@@ -259,7 +260,7 @@ $totalPages = ceil($totalProducts / $limit);
                                     </div>
                                     
                                     <div class="d-grid gap-2">
-                                        <button class="btn btn-primary hover-lift" onclick="addToCart(<?php echo $prod['id']; ?>)">
+                                        <button class="btn btn-primary hover-lift" onclick="addToCart(<?php echo $prod['id']; ?>, '<?php echo addslashes($prod['name']); ?>', <?php echo $finalPrice; ?>, '<?php echo $prod['image'] ?: 'assets/images/placeholder.jpg'; ?>')">
                                             <i class="fas fa-cart-plus me-2"></i>
                                             Agregar al Carrito
                                         </button>
@@ -379,7 +380,7 @@ $totalPages = ceil($totalProducts / $limit);
                 <div class="col-lg-2 col-md-6 mb-4">
                     <h6 class="fw-bold mb-3">Contacto</h6>
                     <ul class="list-unstyled text-muted">
-                        <li><i class="fas fa-map-marker-alt me-2"></i>Latacunga, Ecuador</li>
+                        <li><i class="fas fa-map-marker-alt me-2"></i>Anbato, Ecuador</li>
                         <li><i class="fas fa-phone me-2"></i>+593 983015307</li>
                         <li><i class="fas fa-envelope me-2"></i>kevinmoyolema13@gmail.com</li>
                     </ul>
@@ -391,7 +392,7 @@ $totalPages = ceil($totalProducts / $limit);
                     <p class="text-muted mb-0">&copy; 2025 AlquimiaTechnologic. Desarrollado por AlquimiaTechnologic. Todos los derechos reservados.</p>
                 </div>
                 <div class="col-md-6 text-md-end">
-                    <p class="text-muted mb-0">Hecho con <i class="fas fa-heart text-danger"></i> en Colombia</p>
+                    <p class="text-muted mb-0">Hecho con <i class="fas fa-heart text-danger"></i> en Ecuador</p>
                 </div>
             </div>
         </div>
@@ -437,7 +438,7 @@ $totalPages = ceil($totalProducts / $limit);
                         <div class="price mb-3">
                             <span class="h4 text-primary">$99.000</span>
                         </div>
-                        <button class="btn btn-primary w-100 mb-2" onclick="addToCart(${productId})">
+                        <button class="btn btn-primary w-100 mb-2" onclick="addToCart(${productId}, 'Producto Ejemplo', 99000, 'assets/images/placeholder.jpg')">
                             <i class="fas fa-cart-plus me-2"></i>
                             Agregar al Carrito
                         </button>

--- a/contact.php
+++ b/contact.php
@@ -641,7 +641,7 @@ require_once 'config/config.php';
 
                 <div class="col-md-6 text-md-end">
 
-                    <p class="text-muted mb-0">Hecho con <i class="fas fa-heart text-danger"></i> en Colombia</p>
+                    <p class="text-muted mb-0">Hecho con <i class="fas fa-heart text-danger"></i> en Ecuador</p>
 
                 </div>
 

--- a/index.php
+++ b/index.php
@@ -313,8 +313,9 @@ if ($heroImage && strpos($heroImage, 'http') !== 0) {
                                      class="img-fluid"
                                      loading="lazy"
                                      onerror="this.src='assets/images/placeholder.jpg';">
+                                <?php $finalPrice = (isset($product['discount_percentage']) && $product['discount_percentage'] > 0) ? $product['price'] * (1 - $product['discount_percentage']/100) : $product['price']; ?>
                                 <div class="product-overlay">
-                                    <button class="btn btn-light btn-sm me-2 hover-glow" onclick="addToCart(<?php echo $product['id']; ?>)">
+                                    <button class="btn btn-light btn-sm me-2 hover-glow" onclick="addToCart(<?php echo $product['id']; ?>, '<?php echo addslashes($product['name']); ?>', <?php echo $finalPrice; ?>, '<?php echo $product['image'] ?: 'assets/images/placeholder.jpg'; ?>')">
                                         <i class="fas fa-shopping-cart"></i>
                                     </button>
                                     <button class="btn btn-light btn-sm hover-glow">
@@ -349,7 +350,7 @@ if ($heroImage && strpos($heroImage, 'http') !== 0) {
                                         <?php endfor; ?>
                                     </div>
                                 </div>
-                                <button class="btn btn-primary w-100 mt-3 hover-lift" onclick="addToCart(<?php echo $product['id']; ?>)">
+                                <button class="btn btn-primary w-100 mt-3 hover-lift" onclick="addToCart(<?php echo $product['id']; ?>, '<?php echo addslashes($product['name']); ?>', <?php echo $finalPrice; ?>, '<?php echo $product['image'] ?: 'assets/images/placeholder.jpg'; ?>')">
                                     <i class="fas fa-cart-plus me-2"></i>
                                     Agregar al Carrito
                                 </button>

--- a/orders.php
+++ b/orders.php
@@ -489,7 +489,7 @@ if ($orderId) {
                 <div class="col-lg-2 col-md-6 mb-4">
                     <h6 class="fw-bold mb-3">Contacto</h6>
                     <ul class="list-unstyled text-muted">
-                        <li><i class="fas fa-map-marker-alt me-2"></i>Latacunga, Ecuador</li>
+                        <li><i class="fas fa-map-marker-alt me-2"></i>Anbato, Ecuador</li>
                         <li><i class="fas fa-phone me-2"></i>+593 983015307</li>
                         <li><i class="fas fa-envelope me-2"></i>kevinmoyolema13@gmail.com</li>
                     </ul>
@@ -501,7 +501,7 @@ if ($orderId) {
                     <p class="text-muted mb-0">&copy; 2025 AlquimiaTechnologic. Desarrollado por AlquimiaTechnologic. Todos los derechos reservados.</p>
                 </div>
                 <div class="col-md-6 text-md-end">
-                    <p class="text-muted mb-0">Hecho con <i class="fas fa-heart text-danger"></i> en Colombia</p>
+                    <p class="text-muted mb-0">Hecho con <i class="fas fa-heart text-danger"></i> en Ecuador</p>
                 </div>
             </div>
         </div>

--- a/product.php
+++ b/product.php
@@ -41,6 +41,11 @@ if (empty($productImages)) {
 
 $mainImage = $productImages[0] ?? 'assets/images/placeholder.jpg';
 
+// Calcular precio final teniendo en cuenta descuentos
+$finalPrice = ($productData['discount_percentage'] > 0)
+    ? $productData['price'] * (1 - $productData['discount_percentage'] / 100)
+    : $productData['price'];
+
 // Obtener categoría del producto
 $productCategory = $category->getCategoryById($productData['category_id']);
 
@@ -304,7 +309,7 @@ unset($rp);
                             </div>
 
                             <div class="d-grid gap-2">
-                                <button class="btn btn-primary btn-lg hover-lift" onclick="addToCart(<?php echo $productData['id']; ?>)">
+                                <button class="btn btn-primary btn-lg hover-lift" onclick="addToCart(<?php echo $productData['id']; ?>, '<?php echo addslashes($productData['name']); ?>', <?php echo $finalPrice; ?>, '<?php echo $mainImage; ?>')">
                                     <i class="fas fa-cart-plus me-2"></i>
                                     Agregar al Carrito
                                 </button>
@@ -382,7 +387,7 @@ unset($rp);
                                                 <li class="mb-2"><strong>Material:</strong> Premium</li>
                                                 <li class="mb-2"><strong>Color:</strong> Varios</li>
                                                 <li class="mb-2"><strong>Garantía:</strong> 30 días</li>
-                                                <li class="mb-2"><strong>Origen:</strong> Colombia</li>
+                                                <li class="mb-2"><strong>Origen:</strong> Ecuador</li>
                                             </ul>
                                         </div>
                                     </div>
@@ -443,7 +448,7 @@ unset($rp);
                                             <ul class="list-unstyled">
                                                 <li class="mb-2">
                                                     <i class="fas fa-check text-success me-2"></i>
-                                                    Todo Colombia
+                                                    Todo Ecuador
                                                 </li>
                                                 <li class="mb-2">
                                                     <i class="fas fa-check text-success me-2"></i>
@@ -478,7 +483,7 @@ unset($rp);
                                                  loading="lazy"
                                                  onerror="this.src='assets/images/placeholder.jpg';">
                                             <div class="product-overlay">
-                                                <button class="btn btn-light btn-sm me-2 hover-glow" onclick="addToCart(<?php echo $related['id']; ?>)" title="Agregar al carrito">
+                                                <button class="btn btn-light btn-sm me-2 hover-glow" onclick="addToCart(<?php echo $related['id']; ?>, '<?php echo addslashes($related['name']); ?>', <?php echo ($related['discount_percentage'] > 0 ? $related['price'] * (1 - $related['discount_percentage'] / 100) : $related['price']); ?>, '<?php echo $related['image'] ?: 'assets/images/placeholder.jpg'; ?>')" title="Agregar al carrito">
                                                     <i class="fas fa-shopping-cart"></i>
                                                 </button>
                                                 <a href="product.php?id=<?php echo $related['id']; ?>" class="btn btn-light btn-sm hover-glow" title="Ver producto">
@@ -500,7 +505,7 @@ unset($rp);
                                                     <span class="fw-bold text-primary">$<?php echo number_format($related['price'], 0, ',', '.'); ?></span>
                                                 <?php endif; ?>
                                             </div>
-                                            <button class="btn btn-primary btn-sm w-100" onclick="addToCart(<?php echo $related['id']; ?>)">
+                                            <button class="btn btn-primary btn-sm w-100" onclick="addToCart(<?php echo $related['id']; ?>, '<?php echo addslashes($related['name']); ?>', <?php echo ($related['discount_percentage'] > 0 ? $related['price'] * (1 - $related['discount_percentage'] / 100) : $related['price']); ?>, '<?php echo $related['image'] ?: 'assets/images/placeholder.jpg'; ?>')">
                                                 <i class="fas fa-cart-plus me-2"></i>
                                                 Agregar al Carrito
                                             </button>
@@ -565,7 +570,7 @@ unset($rp);
                 <div class="col-lg-2 col-md-6 mb-4">
                     <h6 class="fw-bold mb-3">Contacto</h6>
                     <ul class="list-unstyled text-muted">
-                        <li><i class="fas fa-map-marker-alt me-2"></i>Latacunga, Ecuador</li>
+                        <li><i class="fas fa-map-marker-alt me-2"></i>Anbato, Ecuador</li>
                         <li><i class="fas fa-phone me-2"></i>+593 983015307</li>
                         <li><i class="fas fa-envelope me-2"></i>kevinmoyolema13@gmail.com</li>
                     </ul>
@@ -577,7 +582,7 @@ unset($rp);
                     <p class="text-muted mb-0">&copy; 2025 AlquimiaTechnologic. Desarrollado por AlquimiaTechnologic. Todos los derechos reservados.</p>
                 </div>
                 <div class="col-md-6 text-md-end">
-                    <p class="text-muted mb-0">Hecho con <i class="fas fa-heart text-danger"></i> en Colombia</p>
+                    <p class="text-muted mb-0">Hecho con <i class="fas fa-heart text-danger"></i> en Ecuador</p>
                 </div>
             </div>
         </div>
@@ -617,17 +622,17 @@ unset($rp);
         }
         
         // Add to cart with quantity
-        function addToCart(productId) {
+        function addToCart(productId, name, price, image) {
             const quantity = parseInt(document.getElementById('quantity').value) || 1;
             const cart = JSON.parse(localStorage.getItem('cart')) || [];
-            
+
             const existingItem = cart.find(item => item.id == productId);
             if (existingItem) {
                 existingItem.quantity += quantity;
             } else {
-                cart.push({ id: productId, quantity: quantity });
+                cart.push({ id: productId, name: name, price: price, image: image, quantity: quantity });
             }
-            
+
             localStorage.setItem('cart', JSON.stringify(cart));
             updateCartCount();
             showNotification('Producto agregado al carrito', 'success');

--- a/products.php
+++ b/products.php
@@ -275,8 +275,9 @@ $categories = $category->getAllCategories();
                                          class="img-fluid"
                                          loading="lazy"
                                          onerror="this.src='assets/images/placeholder.jpg';">
+                                    <?php $finalPrice = (isset($prod['discount_percentage']) && $prod['discount_percentage'] > 0) ? $prod['price'] * (1 - $prod['discount_percentage']/100) : $prod['price']; ?>
                                     <div class="product-overlay">
-                                        <button class="btn btn-light btn-sm me-2 hover-glow" onclick="addToCart(<?php echo $prod['id']; ?>)" title="Agregar al carrito">
+                                        <button class="btn btn-light btn-sm me-2 hover-glow" onclick="addToCart(<?php echo $prod['id']; ?>, '<?php echo addslashes($prod['name']); ?>', <?php echo $finalPrice; ?>, '<?php echo $prod['image'] ?: 'assets/images/placeholder.jpg'; ?>')" title="Agregar al carrito">
                                             <i class="fas fa-shopping-cart"></i>
                                         </button>
                                         <button class="btn btn-light btn-sm me-2 hover-glow" onclick="quickView(<?php echo $prod['id']; ?>)" title="Vista rápida">
@@ -340,7 +341,7 @@ $categories = $category->getAllCategories();
                                     </div>
                                     
                                     <div class="d-grid gap-2">
-                                        <button class="btn btn-primary hover-lift" onclick="addToCart(<?php echo $prod['id']; ?>)">
+                                        <button class="btn btn-primary hover-lift" onclick="addToCart(<?php echo $prod['id']; ?>, '<?php echo addslashes($prod['name']); ?>', <?php echo $finalPrice; ?>, '<?php echo $prod['image'] ?: 'assets/images/placeholder.jpg'; ?>')">
                                             <i class="fas fa-cart-plus me-2"></i>
                                             Agregar al Carrito
                                         </button>
@@ -467,7 +468,7 @@ $categories = $category->getAllCategories();
                 <div class="col-lg-2 col-md-6 mb-4">
                     <h6 class="fw-bold mb-3">Contacto</h6>
                     <ul class="list-unstyled text-muted">
-                        <li><i class="fas fa-map-marker-alt me-2"></i>Bogotá, Colombia</li>
+                        <li><i class="fas fa-map-marker-alt me-2"></i>Bogotá, Ecuador</li>
                         <li><i class="fas fa-phone me-2"></i>+57 123 456 7890</li>
                         <li><i class="fas fa-envelope me-2"></i>kevinmoyolema13@gmail.com</li>
                     </ul>
@@ -479,7 +480,7 @@ $categories = $category->getAllCategories();
                     <p class="text-muted mb-0">&copy; 2025 AlquimiaTechnologic. Desarrollado por AlquimiaTechnologic. Todos los derechos reservados.</p>
                 </div>
                 <div class="col-md-6 text-md-end">
-                    <p class="text-muted mb-0">Hecho con <i class="fas fa-heart text-danger"></i> en Colombia</p>
+                    <p class="text-muted mb-0">Hecho con <i class="fas fa-heart text-danger"></i> en Ecuador</p>
                 </div>
             </div>
         </div>
@@ -548,7 +549,7 @@ $categories = $category->getAllCategories();
                         <div class="price mb-3">
                             <span class="h4 text-primary">$99.000</span>
                         </div>
-                        <button class="btn btn-primary w-100" onclick="addToCart(${productId})">
+                        <button class="btn btn-primary w-100" onclick="addToCart(${productId}, 'Producto Ejemplo', 99000, 'assets/images/placeholder.jpg')">
                             <i class="fas fa-cart-plus me-2"></i>
                             Agregar al Carrito
                         </button>

--- a/profile.php
+++ b/profile.php
@@ -428,7 +428,7 @@ $userOrders = $order->getOrdersByUserId($_SESSION['user_id']);
                 <div class="col-lg-2 col-md-6 mb-4">
                     <h6 class="fw-bold mb-3">Contacto</h6>
                     <ul class="list-unstyled text-muted">
-                        <li><i class="fas fa-map-marker-alt me-2"></i>Latacunga, Ecuador</li>
+                        <li><i class="fas fa-map-marker-alt me-2"></i>Anbato, Ecuador</li>
                         <li><i class="fas fa-phone me-2"></i>+593 983015307</li>
                         <li><i class="fas fa-envelope me-2"></i>kevinmoyolema13@gmail.com</li>
                     </ul>
@@ -440,7 +440,7 @@ $userOrders = $order->getOrdersByUserId($_SESSION['user_id']);
                     <p class="text-muted mb-0">&copy; 2025 AlquimiaTechnologic. Desarrollado por AlquimiaTechnologic. Todos los derechos reservados.</p>
                 </div>
                 <div class="col-md-6 text-md-end">
-                    <p class="text-muted mb-0">Hecho con <i class="fas fa-heart text-danger"></i> en Colombia</p>
+                    <p class="text-muted mb-0">Hecho con <i class="fas fa-heart text-danger"></i> en Ecuador</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- store full product data in cart items for correct display
- use the stored details when rendering the cart
- update `addToCart` calls across the site
- replace mentions of Latacunga with Anbato and Colombia with Ecuador

## Testing
- `php -l product.php`
- `php -l index.php`
- `php -l products.php`
- `php -l category.php`
- `php -l cart.php`
- `php test_system.php` *(fails: getaddrinfo for sql308.infinityfree.com failed)*

------
https://chatgpt.com/codex/tasks/task_b_6878ee0e67e4833391576df09d7d7724