### PR TITLE
Fix cart and quick view

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -42,13 +42,18 @@ function updateCartCount() {
 }
 
 function addToCart(productId, name, price, image, quantity = 1) {
-    // Find if product already exists in cart
+    try {
+        cart = JSON.parse(localStorage.getItem('cart')) || [];
+    } catch (e) {
+        console.error('Failed to read cart from localStorage', e);
+        cart = cart || [];
+    }
+
     const existingItem = cart.find(item => item.id == productId);
 
     if (existingItem) {
         existingItem.quantity += quantity;
     } else {
-        // Store product details for later display
         cart.push({
             id: productId,
             name: name,
@@ -58,15 +63,16 @@ function addToCart(productId, name, price, image, quantity = 1) {
             timestamp: new Date().toISOString()
         });
     }
-    
-    // Save to localStorage
-    localStorage.setItem('cart', JSON.stringify(cart));
-    
-    // Update UI with animations
+
+    try {
+        localStorage.setItem('cart', JSON.stringify(cart));
+    } catch (e) {
+        console.error('Failed to save cart to localStorage', e);
+    }
+
     updateCartCount();
+    updateCartDisplay();
     showNotification('🛒 Producto agregado al carrito', 'success');
-    
-    // Add floating animation
     createFloatingCartIcon();
 }
 

--- a/category.php
+++ b/category.php
@@ -38,6 +38,7 @@ $totalPages = ceil($totalProducts / $limit);
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <link href="assets/css/style.css" rel="stylesheet">
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
+    <script>const SITE_URL = '<?php echo SITE_URL; ?>';</script>
 </head>
 <body>
     <!-- Navigation -->
@@ -430,7 +431,7 @@ $totalPages = ceil($totalProducts / $limit);
             content.innerHTML = '<div class="text-center py-5"><div class="spinner-border" role="status"></div></div>';
             modal.show();
 
-            fetch('quick_view.php?id=' + productId)
+            fetch(SITE_URL + '/quick_view.php?id=' + productId)
                 .then(res => res.json())
                 .then(data => {
                     if (!data.success) {

--- a/products.php
+++ b/products.php
@@ -50,6 +50,7 @@ $categories = $category->getAllCategories();
     
     <!-- AOS Animation Library -->
     <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
+    <script>const SITE_URL = '<?php echo SITE_URL; ?>';</script>
 </head>
 <body>
     <!-- Navigation -->
@@ -540,7 +541,7 @@ $categories = $category->getAllCategories();
             content.innerHTML = '<div class="text-center py-5"><div class="spinner-border" role="status"></div></div>';
             modal.show();
 
-            fetch('quick_view.php?id=' + productId)
+            fetch(SITE_URL + '/quick_view.php?id=' + productId)
                 .then(res => res.json())
                 .then(data => {
                     if (!data.success) {


### PR DESCRIPTION
## Summary
- make cart operations resilient to localStorage issues
- show cart immediately after adding items
- ensure quick view works when the site is installed in a subfolder by using `SITE_URL`

## Testing
- `php check_php_config.php`
- `php check_database_connection.php` *(fails: getaddrinfo for sql308.infinityfree.com)*
- `php test_system.php` *(fails: getaddrinfo for sql308.infinityfree.com)*

------
https://chatgpt.com/codex/tasks/task_b_6879395915d88333827005a46d91d793