### PR TITLE
Fix quick view fetch and cart updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+database/database.sqlite

--- a/cart.php
+++ b/cart.php
@@ -283,6 +283,9 @@ $product = new Product();
                     </div>
                 `;
                 updateCartSummary();
+                if (typeof updateCartCount === 'function') {
+                    updateCartCount();
+                }
                 return;
             }
             
@@ -334,6 +337,9 @@ $product = new Product();
             
             cartContainer.innerHTML = cartHTML;
             updateCartSummary();
+            if (typeof updateCartCount === 'function') {
+                updateCartCount();
+            }
         }
         
         function updateQuantity(productId, change) {

--- a/category.php
+++ b/category.php
@@ -431,7 +431,7 @@ $totalPages = ceil($totalProducts / $limit);
             content.innerHTML = '<div class="text-center py-5"><div class="spinner-border" role="status"></div></div>';
             modal.show();
 
-            fetch(SITE_URL + '/quick_view.php?id=' + productId)
+            fetch('quick_view.php?id=' + productId)
                 .then(res => res.json())
                 .then(data => {
                     if (!data.success) {

--- a/products.php
+++ b/products.php
@@ -541,7 +541,7 @@ $categories = $category->getAllCategories();
             content.innerHTML = '<div class="text-center py-5"><div class="spinner-border" role="status"></div></div>';
             modal.show();
 
-            fetch(SITE_URL + '/quick_view.php?id=' + productId)
+            fetch('quick_view.php?id=' + productId)
                 .then(res => res.json())
                 .then(data => {
                     if (!data.success) {


### PR DESCRIPTION
## Summary
- improve quick view fetch URLs to use relative paths
- keep cart count in sync when cart contents change
- ignore sqlite database files

## Testing
- `php -l category.php`
- `php -l products.php`
- `php -l cart.php`
- `php test_system.php` *(fails: sql308.infinityfree.com name resolution)*

------
https://chatgpt.com/codex/tasks/task_b_687943239c6c8333b6cdbd42b0a99072